### PR TITLE
removed provider block to enable new terraform features

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,10 +9,6 @@
 # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/US_SetupSNS.html
 ##################################################################
 
-provider "aws" {
-  region = var.aws_region
-}
-
 resource "aws_sns_topic_subscription" "sns-subscription" {
   count     = var.use_sns ? 1 : 0
   topic_arn = var.sns_arn

--- a/variables.tf
+++ b/variables.tf
@@ -35,12 +35,6 @@ variable "cpu_utilization_threshold" {
   default     = "90"
 }
 
-variable "aws_region" {
-  type        = string
-  description = "Specify what region to create resources in"
-  default     = "us-west-2"
-}
-
 variable "alert_email" {
   type        = string
   description = "Specify the email you'd like the alerts to go to"


### PR DESCRIPTION
According to this documentation by hashicorp https://developer.hashicorp.com/terraform/language/modules/develop/providers

> A module intended to be called by one or more other modules must not contain any provider blocks. A module containing its own provider configurations is not compatible with the for_each, count, and depends_on arguments that were introduced in Terraform v0.13. For more information, see [Legacy Shared Modules with Provider Configurations](https://developer.hashicorp.com/terraform/language/modules/develop/providers#legacy-shared-modules-with-provider-configurations).

Due to this, we must assume that all of our modules are going to inherit their provider configurations implicitly. Which means removing this block was necessary to allow our modules to be dynamically generated with meta-arguments.

Currently, if you try to generate multiple of these module resources dynamically within a root module. You receive an error like the following

```
The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.
╷
│ Error: Module is incompatible with count, for_each, and depends_on
│ 
│   on ***.tf line 2, in module "terraform-aws-ecs-cloudwatch-alerts":
│    2:   count = 2
│ 
│ The module at module.terraform-aws-ecs-cloudwatch-alerts is a legacy module which contains its own local
│ provider configurations, and so calls to it may not use the count, for_each, or depends_on arguments.
```