### PR TITLE
added logic for environment to be passed as variable for naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alert_email"></a> [alert\_email](#input\_alert\_email) | Specify the email you'd like the alerts to go to (Unneccessary if create\_sns\_subscription is false) | `string` | `"alerts@synapsestudios.com"` | no |
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Cluster name of ECS service to be alerted on (Example: puppies-production) | `string` | `"service-production"` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Cluster name of ECS service to be alerted on (Example: service-production) | `string` | `"service-production"` | no |
 | <a name="input_cpu_utilization_threshold"></a> [cpu\_utilization\_threshold](#input\_cpu\_utilization\_threshold) | Desired CPU Utilization threshold that will be compared in alert (Example: 90 for 90% average over 60 seconds in ECS Service) | `string` | `"90"` | no |
 | <a name="input_create_sns_subscription"></a> [create\_sns\_subscription](#input\_create\_sns\_subscription) | Set to true to create a sns subscription to the topic for created alarms | `bool` | `true` | no |
 | <a name="input_desired_task_threshold"></a> [desired\_task\_threshold](#input\_desired\_task\_threshold) | Desired task threshold that will be compared in alert (Example: 1 for alerts below 1 running task in ECS Service) | `string` | `"1"` | no |
-| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Service name of ECS service to be alerted on (Example: puppies-api, puppies-job\_queue) | `string` | `"appname-api"` | no |
+| <a name="input_env"></a> [env](#input\_env) | Specify the environment you're deploying to (Example: staging, dev, test) (leave null for production) | `string` | `null` | no |
+| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Service name of ECS service to be alerted on (Example: appname-api, appname-job\_queue) | `string` | `"appname-api"` | no |
 | <a name="input_sns_arn"></a> [sns\_arn](#input\_sns\_arn) | Full arn of the desired sns topic to subscribe alarm to (Example: arn:aws:sns:region-name:XXXX:cloudwatch-topic) | `string` | `"arn:aws:sns:region-name:XXXX:cloudwatch-topic"` | no |
 | <a name="input_use_sns"></a> [use\_sns](#input\_use\_sns) | Use SNS for notifications | `bool` | `true` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "aws_sns_topic_subscription" "sns-subscription" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "task-count-alarm" {
-  alarm_name          = "runningTaskCount-${var.service_name}-alarm"
+  alarm_name          = "runningTaskCount-${var.service_name}-${var.env != null ? format("%s/%s", "-", var.env) : var.env}-alarm"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = "2"
   metric_name         = "MemoryUtilization"
@@ -36,7 +36,7 @@ resource "aws_cloudwatch_metric_alarm" "task-count-alarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu-utilization-alarm" {
-  alarm_name          = "cpuUtilization-${var.service_name}-alarm"
+  alarm_name          = "cpuUtilization-${var.service_name}${var.env != null ? format("%s/%s", "-", var.env) : var.env}-alarm"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "2"
   metric_name         = "CPUUtilization"

--- a/variables.tf
+++ b/variables.tf
@@ -18,13 +18,13 @@ variable "sns_arn" {
 
 variable "cluster_name" {
   type        = string
-  description = "Cluster name of ECS service to be alerted on (Example: puppies-production)"
+  description = "Cluster name of ECS service to be alerted on (Example: service-production)"
   default     = "service-production"
 }
 
 variable "service_name" {
   type        = string
-  description = "Service name of ECS service to be alerted on (Example: puppies-api, puppies-job_queue)"
+  description = "Service name of ECS service to be alerted on (Example: appname-api, appname-job_queue)"
   default     = "appname-api"
 }
 
@@ -44,4 +44,10 @@ variable "alert_email" {
   type        = string
   description = "Specify the email you'd like the alerts to go to (Unneccessary if create_sns_subscription is false)"
   default     = "alerts@synapsestudios.com"
+}
+
+variable "env" {
+  type        = string
+  description = "Specify the environment you're deploying to (Example: staging, dev, test) (leave null for production)"
+  default     = null
 }


### PR DESCRIPTION
https://github.com/synapsestudios/terraform-aws-ecs-cloudwatch-alerts/issues/8

- Added null check to naming so if it's left blank nothing is added to the `alarm_name` field and if it is not null it adds the `var.env` with a dash in between
- Fixed examples in variables